### PR TITLE
Added a stream writer to stream csv data from Neo4j

### DIFF
--- a/neo4j-to-neptune/pom.xml
+++ b/neo4j-to-neptune/pom.xml
@@ -47,6 +47,35 @@
             <version>2.10.5</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.neo4j.driver/neo4j-java-driver -->
+        <dependency>
+            <groupId>org.neo4j.driver</groupId>
+            <artifactId>neo4j-java-driver</artifactId>
+            <version>5.28.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>neptune</artifactId>
+            <version>2.31.32</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>neptunedata</artifactId>
+            <version>2.31.32</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>2.31.32</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.cdimascio</groupId>
+            <artifactId>dotenv-java</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/neo4j-to-neptune/src/main/java/com/amazonaws/services/neptune/io/Neo4jStreamWriter.java
+++ b/neo4j-to-neptune/src/main/java/com/amazonaws/services/neptune/io/Neo4jStreamWriter.java
@@ -1,0 +1,309 @@
+/*
+Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package com.amazonaws.services.neptune.io;
+
+import org.neo4j.driver.*;
+import org.neo4j.driver.exceptions.Neo4jException;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import java.util.logging.Level;
+
+/**
+ * A writer class that streams data from Neo4j database to CSV files.
+ * This class handles the connection to Neo4j, executes export queries,
+ * and writes the results to temporary files for further processing.
+ */
+public class Neo4jStreamWriter implements AutoCloseable {
+
+    private static final Logger LOGGER = Logger.getLogger(Neo4jStreamWriter.class.getName());
+    private static final String TEMP_FILE = "neo4j-stream-data";
+    
+    private final Directories directories;
+    private final Driver driver;
+    private final Neo4jStreamWriterConfig config;
+
+    /**
+     * Creates a new Neo4jStreamWriter with default configuration.
+     *
+     * @param uri The Neo4j database URI
+     * @param username The database username
+     * @param password The database password
+     * @param directories The directories helper for file management
+     * @throws IllegalArgumentException if any parameter is null or invalid
+     */
+    public Neo4jStreamWriter(String uri, String username, String password, Directories directories) {
+        this(uri, username, password, directories, Neo4jStreamWriterConfig.defaultConfig());
+    }
+
+    /**
+     * Creates a new Neo4jStreamWriter with custom configuration.
+     *
+     * @param uri The Neo4j database URI
+     * @param username The database username
+     * @param password The database password
+     * @param directories The directories helper for file management
+     * @param config The configuration for the Neo4j driver
+     * @throws IllegalArgumentException if any parameter is null or invalid
+     */
+    public Neo4jStreamWriter(String uri, String username, String password, Directories directories, Neo4jStreamWriterConfig config) {
+        validateInputs(uri, username, password, directories, config);
+        
+        this.directories = directories;
+        this.config = config;
+        
+        try {
+            this.driver = GraphDatabase.driver(uri, AuthTokens.basic(username, password),
+                Config.builder()
+                    .withConnectionTimeout(config.getConnectionTimeoutSeconds(), TimeUnit.SECONDS)
+                    .withMaxConnectionLifetime(config.getMaxConnectionLifetimeMinutes(), TimeUnit.MINUTES)
+                    .build());
+
+            driver.verifyConnectivity();
+
+            LOGGER.info("Successfully connected to Neo4j database at: " + uri);
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Failed to connect to Neo4j database at: " + uri, e);
+            throw new RuntimeException("Failed to connect to Neo4j database", e);
+        }
+    }
+
+    /**
+     * Issues a query to the database to stream all data back inside the "data" column in CSV format
+     * and writes it to a temporary file for conversion.
+     *
+     * @return The file containing the exported data, or null if the operation failed
+     */
+    public File streamToFile() {
+        return streamToFile(TEMP_FILE);
+    }
+
+    /**
+     * Issues a query to the database to stream all data back inside the "data" column in CSV format
+     * and writes it to a temporary file for conversion.
+     *
+     * @param baseFileName The base name for the output file
+     * @return The file containing the exported data, or null if the operation failed
+     */
+    public File streamToFile(String baseFileName) {
+        if (baseFileName == null || baseFileName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Base file name cannot be null or empty");
+        }
+
+        Path tempFilePath = directories.createFilePath(baseFileName, "temp");
+        File file = tempFilePath.toFile();
+        
+        LOGGER.info("Starting data export to file: " + file.getAbsolutePath());
+
+        try (BufferedWriter writer = Files.newBufferedWriter(tempFilePath, StandardCharsets.UTF_8);
+             Session session = driver.session()) {
+
+            String exportQuery = buildExportQuery();
+            LOGGER.fine("Executing query: " + exportQuery);
+
+            Result result = session.run(exportQuery);
+            long recordCount = 0;
+            long lineCount = 0;
+
+            while (result.hasNext()) {
+                Record record = result.next();
+                recordCount++;
+                
+                Map<String, Object> recordMap = record.asMap();
+                logRecordInfo(recordMap, recordCount);
+                
+                Object dataObject = recordMap.get("data");
+                if (dataObject != null) {
+                    lineCount += processDataObject(dataObject, writer);
+                }
+            }
+
+            LOGGER.info(String.format("Successfully exported %d records (%d lines) to file: %s", 
+                recordCount, lineCount, file.getAbsolutePath()));
+            return file;
+
+        } catch (Neo4jException e) {
+            LOGGER.log(Level.SEVERE, "Neo4j database error during export", e);
+            return null;
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, "IO error while writing to file: " + file.getAbsolutePath(), e);
+            return null;
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Unexpected error during data export", e);
+            return null;
+        }
+    }
+
+    /**
+     * Executes a custom Cypher query and streams the results to a file.
+     *
+     * @param query The Cypher query to execute
+     * @param baseFileName The base name for the output file
+     * @return The file containing the exported data, or null if the operation failed
+     */
+    public File streamCustomQueryToFile(String query, String baseFileName) {
+        if (query == null || query.trim().isEmpty()) {
+            throw new IllegalArgumentException("Query cannot be null or empty");
+        }
+        if (baseFileName == null || baseFileName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Base file name cannot be null or empty");
+        }
+
+        Path tempFilePath = directories.createFilePath(baseFileName, "custom");
+        File file = tempFilePath.toFile();
+
+        LOGGER.info("Starting custom query export to file: " + file.getAbsolutePath());
+
+        try (BufferedWriter writer = Files.newBufferedWriter(tempFilePath, StandardCharsets.UTF_8);
+             Session session = driver.session()) {
+
+            LOGGER.fine("Executing custom query: " + query);
+
+            Result result = session.run(query);
+            long recordCount = 0;
+
+            while (result.hasNext()) {
+                Record record = result.next();
+                recordCount++;
+
+                // Write the entire record as a line
+                writer.write(record.toString());
+                writer.newLine();
+            }
+
+            LOGGER.info(String.format("Successfully exported %d records from custom query to file: %s",
+                recordCount, file.getAbsolutePath()));
+            return file;
+
+        } catch (Neo4jException e) {
+            LOGGER.log(Level.SEVERE, "Neo4j database error during custom query export", e);
+            return null;
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, "IO error while writing to file: " + file.getAbsolutePath(), e);
+            return null;
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Unexpected error during custom query export", e);
+            return null;
+        }
+    }
+
+    @Override
+    public void close() {
+        if (driver != null) {
+            try {
+                driver.close();
+                LOGGER.info("Neo4j driver closed successfully");
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Error closing Neo4j driver", e);
+            }
+        }
+    }
+
+    private void validateInputs(String uri, String username, String password, Directories directories, Neo4jStreamWriterConfig config) {
+        if (uri == null || uri.trim().isEmpty()) {
+            throw new IllegalArgumentException("URI cannot be null or empty");
+        }
+        if (username == null) {
+            throw new IllegalArgumentException("Username cannot be null");
+        }
+        if (password == null) {
+            throw new IllegalArgumentException("Password cannot be null");
+        }
+        if (directories == null) {
+            throw new IllegalArgumentException("Directories cannot be null");
+        }
+        if (config == null) {
+            throw new IllegalArgumentException("Config cannot be null");
+        }
+    }
+
+    private String buildExportQuery() {
+        StringBuilder queryBuilder = new StringBuilder();
+        queryBuilder.append("CALL apoc.export.csv.all(null, {stream:true");
+        
+        if (config.getBatchSize() > 0) {
+            queryBuilder.append(", batchSize:").append(config.getBatchSize());
+        }
+        
+        queryBuilder.append("})\n")
+                   .append("YIELD file, nodes, relationships, properties, data\n")
+                   .append("RETURN file, nodes, relationships, properties, data");
+        
+        return queryBuilder.toString();
+    }
+
+    private void logRecordInfo(Map<String, Object> recordMap, long recordCount) {
+        if (LOGGER.isLoggable(Level.FINE)) {
+            Object nodes = recordMap.get("nodes");
+            Object relationships = recordMap.get("relationships");
+            Object properties = recordMap.get("properties");
+            
+            LOGGER.fine(String.format("Processing record %d - Nodes: %s, Relationships: %s, Properties: %s", 
+                recordCount, nodes, relationships, properties));
+        }
+    }
+
+    private long processDataObject(Object dataObject, BufferedWriter writer) throws IOException {
+        String dataString = dataObject.toString();
+        
+        // Handle different line separator patterns
+        String[] lines = dataString.split("\\r?\\n|%n");
+        long lineCount = 0;
+        
+        for (String line : lines) {
+            if (!line.trim().isEmpty()) {
+                writer.write(line);
+                writer.newLine();
+                lineCount++;
+            }
+        }
+        
+        return lineCount;
+    }
+
+    /**
+     * Configuration class for Neo4jStreamWriter
+     */
+    public static class Neo4jStreamWriterConfig {
+        private final int connectionTimeoutSeconds;
+        private final int maxConnectionLifetimeMinutes;
+        private final int batchSize;
+
+        public Neo4jStreamWriterConfig(int connectionTimeoutSeconds, int maxConnectionLifetimeMinutes, int batchSize) {
+            this.connectionTimeoutSeconds = connectionTimeoutSeconds;
+            this.maxConnectionLifetimeMinutes = maxConnectionLifetimeMinutes;
+            this.batchSize = batchSize;
+        }
+
+        public static Neo4jStreamWriterConfig defaultConfig() {
+            return new Neo4jStreamWriterConfig(30, 60, 1000);
+        }
+
+        public int getConnectionTimeoutSeconds() {
+            return connectionTimeoutSeconds;
+        }
+
+        public int getMaxConnectionLifetimeMinutes() {
+            return maxConnectionLifetimeMinutes;
+        }
+
+        public int getBatchSize() {
+            return batchSize;
+        }
+    }
+}

--- a/neo4j-to-neptune/src/main/java/com/amazonaws/services/neptune/io/Neo4jStreamWriter.java
+++ b/neo4j-to-neptune/src/main/java/com/amazonaws/services/neptune/io/Neo4jStreamWriter.java
@@ -185,7 +185,8 @@ public class Neo4jStreamWriter implements AutoCloseable {
                 writer.write(record.toString());
                 writer.newLine();
             }
-
+            writer.flush();
+            
             LOGGER.info(String.format("Successfully exported %d records from custom query to file: %s",
                 recordCount, file.getAbsolutePath()));
             return file;
@@ -272,6 +273,7 @@ public class Neo4jStreamWriter implements AutoCloseable {
                 lineCount++;
             }
         }
+        writer.flush();
         
         return lineCount;
     }

--- a/neo4j-to-neptune/src/test/java/com/amazonaws/services/neptune/io/Neo4jStreamWriterIntegrationTest.java
+++ b/neo4j-to-neptune/src/test/java/com/amazonaws/services/neptune/io/Neo4jStreamWriterIntegrationTest.java
@@ -1,0 +1,195 @@
+/*
+Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package com.amazonaws.services.neptune.io;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.junit.Assume;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration tests for Neo4jStreamWriter class.
+ * These tests require a running Neo4j database with APOC plugin installed.
+ * 
+ * To run these tests:
+ * 1. Start a Neo4j database (e.g., using Docker: docker run -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/password neo4j:latest)
+ * 2. Install APOC plugin
+ * 3. Set system properties: -Dneo4j.uri=bolt://localhost:7687 -Dneo4j.username=neo4j -Dneo4j.password=password
+ * 4. Run tests
+ */
+public class Neo4jStreamWriterIntegrationTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private Directories directories;
+    private Neo4jStreamWriter writer;
+    
+    // Test configuration - can be overridden with system properties
+    private static final String DEFAULT_URI = "bolt://localhost:7687";
+    private static final String DEFAULT_USERNAME = "neo4j";
+    private static final String DEFAULT_PASSWORD = "password";
+
+    @Before
+    public void setUp() throws IOException {
+        // Create a temporary directory for testing
+        File tempDir = tempFolder.newFolder("integration-test-output");
+        directories = Directories.createFor(tempDir);
+
+        // Get connection details from system properties or use defaults
+        String uri = System.getProperty("neo4j.uri", DEFAULT_URI);
+        String username = System.getProperty("neo4j.username", DEFAULT_USERNAME);
+        String password = System.getProperty("neo4j.password", DEFAULT_PASSWORD);
+
+        try {
+            writer = new Neo4jStreamWriter(uri, username, password, directories);
+
+            createTestData();
+                
+        } catch (Exception e) {
+            Assume.assumeNoException("Neo4j database is not available - skipping integration tests", e);
+        }
+    }
+
+    @After
+    public void tearDown() {
+        if (writer != null) {
+            writer.close();
+        }
+    }
+
+    /**
+     * Helper method to create test data in the Neo4j database
+     */
+    private void createTestData() {
+        // TODO decide on test data set
+    }
+
+    @Test
+    public void testStreamToFileWithRealDatabase() throws IOException {
+        // First, create some test data
+        createTestData();
+
+        // Stream data to file
+        File result = writer.streamToFile("integration-test");
+
+        // Verify results
+        assertNotNull("Result file should not be null", result);
+        assertTrue("Result file should exist", result.exists());
+        assertTrue("Result file should not be empty", result.length() > 0);
+
+        // Read and verify file contents
+        String content = new String(Files.readAllBytes(result.toPath()));
+        assertFalse("File content should not be empty", content.trim().isEmpty());
+        
+        System.out.println("Generated file content preview:");
+        System.out.println(content.substring(0, Math.min(500, content.length())));
+    }
+
+    @Test
+    public void testStreamCustomQueryToFileWithRealDatabase() throws IOException {
+        // Create some test data first
+
+
+        // Execute custom query
+        String customQuery = "MATCH (n) RETURN n.name as name, labels(n) as labels LIMIT 5";
+        File result = writer.streamCustomQueryToFile(customQuery, "custom-query-test");
+
+        // Verify results
+        assertNotNull("Result file should not be null", result);
+        assertTrue("Result file should exist", result.exists());
+        assertTrue("Result file should not be empty", result.length() > 0);
+
+        // Read and verify file contents
+        String content = new String(Files.readAllBytes(result.toPath()));
+        assertFalse("File content should not be empty", content.trim().isEmpty());
+        
+        System.out.println("Custom query result preview:");
+        System.out.println(content.substring(0, Math.min(200, content.length())));
+    }
+
+    @Test
+    public void testStreamToFileWithCustomConfig() throws IOException {
+        // Create writer with custom configuration
+        Neo4jStreamWriter.Neo4jStreamWriterConfig customConfig = 
+            new Neo4jStreamWriter.Neo4jStreamWriterConfig(60, 120, 500);
+
+        String uri = System.getProperty("neo4j.uri", DEFAULT_URI);
+        String username = System.getProperty("neo4j.username", DEFAULT_USERNAME);
+        String password = System.getProperty("neo4j.password", DEFAULT_PASSWORD);
+
+        try (Neo4jStreamWriter customWriter = new Neo4jStreamWriter(uri, username, password, directories, customConfig)) {
+
+            // Create test data and stream
+            File result = customWriter.streamToFile("custom-config-test");
+
+            // Verify results
+            assertNotNull("Result file should not be null", result);
+            assertTrue("Result file should exist", result.exists());
+        }
+    }
+
+    @Test
+    public void testMultipleStreamOperations() throws IOException {
+        // Test multiple streaming operations with the same writer
+        createTestData();
+
+        // First stream operation
+        File result1 = writer.streamToFile("multi-test-1");
+        assertNotNull("First result should not be null", result1);
+        assertTrue("First result should exist", result1.exists());
+
+        // Second stream operation
+        File result2 = writer.streamToFile("multi-test-2");
+        assertNotNull("Second result should not be null", result2);
+        assertTrue("Second result should exist", result2.exists());
+
+        // Verify both files are different (different timestamps in names)
+        assertNotEquals("Files should have different names", result1.getName(), result2.getName());
+    }
+
+    @Test
+    public void testErrorHandlingWithInvalidQuery() throws IOException {
+        // Test with an invalid query that should fail
+        File result = writer.streamCustomQueryToFile("INVALID CYPHER QUERY", "error-test");
+        
+        // Should return null on error
+        assertNull("Result should be null for invalid query", result);
+    }
+
+    @Test
+    public void testLargeDatasetHandling() throws IOException {
+        // Test with a query that returns a larger dataset
+        String largeDataQuery = "UNWIND range(1, 1000) as i RETURN i, 'test_' + toString(i) as name";
+        File result = writer.streamCustomQueryToFile(largeDataQuery, "large-dataset-test");
+
+        if (result != null) {
+            assertTrue("Large dataset file should exist", result.exists());
+            assertTrue("Large dataset file should not be empty", result.length() > 0);
+            
+            // Verify file size is reasonable for 1000 records
+            long fileSize = result.length();
+            assertTrue("File should be reasonably sized for 1000 records", fileSize > 1000);
+            
+            System.out.println("Large dataset file size: " + fileSize + " bytes");
+        }
+    }
+}

--- a/neo4j-to-neptune/src/test/java/com/amazonaws/services/neptune/io/Neo4jStreamWriterIntegrationTest.java
+++ b/neo4j-to-neptune/src/test/java/com/amazonaws/services/neptune/io/Neo4jStreamWriterIntegrationTest.java
@@ -85,8 +85,6 @@ public class Neo4jStreamWriterIntegrationTest {
 
     @Test
     public void testStreamToFileWithRealDatabase() throws IOException {
-        // First, create some test data
-        createTestData();
 
         // Stream data to file
         File result = writer.streamToFile("integration-test");
@@ -149,8 +147,6 @@ public class Neo4jStreamWriterIntegrationTest {
 
     @Test
     public void testMultipleStreamOperations() throws IOException {
-        // Test multiple streaming operations with the same writer
-        createTestData();
 
         // First stream operation
         File result1 = writer.streamToFile("multi-test-1");

--- a/neo4j-to-neptune/src/test/java/com/amazonaws/services/neptune/io/Neo4jStreamWriterTest.java
+++ b/neo4j-to-neptune/src/test/java/com/amazonaws/services/neptune/io/Neo4jStreamWriterTest.java
@@ -174,7 +174,7 @@ public class Neo4jStreamWriterTest {
     @Test
     public void testEmptyStringValidation() {
         // Test various empty string scenarios
-        String[] emptyStrings = {"", "   ", "\t", "\n", "\r\n"};
+        String[] emptyStrings = {"", "   ", "\t", "\n", "\r\n", null};
         
         for (String emptyString : emptyStrings) {
             try {

--- a/neo4j-to-neptune/src/test/java/com/amazonaws/services/neptune/io/Neo4jStreamWriterTest.java
+++ b/neo4j-to-neptune/src/test/java/com/amazonaws/services/neptune/io/Neo4jStreamWriterTest.java
@@ -1,0 +1,227 @@
+/*
+Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package com.amazonaws.services.neptune.io;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for Neo4jStreamWriter class focusing on validation and configuration.
+ * These tests don't require a Neo4j database connection.
+ */
+public class Neo4jStreamWriterTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private Directories directories;
+
+    @Before
+    public void setUp() throws IOException {
+        // Create a temporary directory for testing
+        File tempDir = tempFolder.newFolder("test-output");
+        directories = Directories.createFor(tempDir);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorWithNullUri() {
+        new Neo4jStreamWriter(null, "neo4j", "password", directories);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorWithEmptyUri() {
+        new Neo4jStreamWriter("", "neo4j", "password", directories);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorWithWhitespaceUri() {
+        new Neo4jStreamWriter("   ", "neo4j", "password", directories);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorWithNullUsername() {
+        new Neo4jStreamWriter("bolt://localhost:7687", null, "password", directories);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorWithNullPassword() {
+        new Neo4jStreamWriter("bolt://localhost:7687", "neo4j", null, directories);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorWithNullDirectories() {
+        new Neo4jStreamWriter("bolt://localhost:7687", "neo4j", "password", null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorWithNullConfig() {
+        new Neo4jStreamWriter("bolt://localhost:7687", "neo4j", "password", directories, null);
+    }
+
+    @Test
+    public void testConstructorValidationPasses() {
+        // This will fail with connection error, but validation should pass
+        try  {
+            new Neo4jStreamWriter("bolt://localhost:7687", "neo4j", "password", directories);
+            fail("Should have thrown RuntimeException due to connection failure");
+        } catch (RuntimeException e) {
+            // Expected - connection will fail, but validation passed
+            assertTrue("Should fail due to connection, not validation", 
+                e.getMessage().contains("Failed to connect to Neo4j database"));
+        }
+    }
+
+    @Test
+    public void testConfigurationDefaults() {
+        Neo4jStreamWriter.Neo4jStreamWriterConfig config = 
+            Neo4jStreamWriter.Neo4jStreamWriterConfig.defaultConfig();
+
+        assertEquals("Default connection timeout should be 30 seconds", 
+            30, config.getConnectionTimeoutSeconds());
+        assertEquals("Default max connection lifetime should be 60 minutes", 
+            60, config.getMaxConnectionLifetimeMinutes());
+        assertEquals("Default batch size should be 1000", 
+            1000, config.getBatchSize());
+    }
+
+    @Test
+    public void testCustomConfiguration() {
+        Neo4jStreamWriter.Neo4jStreamWriterConfig config = 
+            new Neo4jStreamWriter.Neo4jStreamWriterConfig(60, 120, 500);
+
+        assertEquals("Custom connection timeout should be 60 seconds", 
+            60, config.getConnectionTimeoutSeconds());
+        assertEquals("Custom max connection lifetime should be 120 minutes", 
+            120, config.getMaxConnectionLifetimeMinutes());
+        assertEquals("Custom batch size should be 500", 
+            500, config.getBatchSize());
+    }
+
+    @Test
+    public void testConfigurationWithZeroValues() {
+        Neo4jStreamWriter.Neo4jStreamWriterConfig config = 
+            new Neo4jStreamWriter.Neo4jStreamWriterConfig(0, 0, 0);
+
+        assertEquals("Zero connection timeout should be allowed", 
+            0, config.getConnectionTimeoutSeconds());
+        assertEquals("Zero max connection lifetime should be allowed", 
+            0, config.getMaxConnectionLifetimeMinutes());
+        assertEquals("Zero batch size should be allowed", 
+            0, config.getBatchSize());
+    }
+
+    @Test
+    public void testConfigurationWithNegativeValues() {
+        Neo4jStreamWriter.Neo4jStreamWriterConfig config = 
+            new Neo4jStreamWriter.Neo4jStreamWriterConfig(-1, -1, -1);
+
+        assertEquals("Negative connection timeout should be allowed", 
+            -1, config.getConnectionTimeoutSeconds());
+        assertEquals("Negative max connection lifetime should be allowed", 
+            -1, config.getMaxConnectionLifetimeMinutes());
+        assertEquals("Negative batch size should be allowed", 
+            -1, config.getBatchSize());
+    }
+
+    @Test
+    public void testDirectoriesIntegration() throws IOException {
+        // Test that the directories object works correctly with the writer
+        assertNotNull("Directories should not be null", directories);
+        assertNotNull("Output directory should not be null", directories.outputDirectory());
+        assertTrue("Output directory should exist", directories.outputDirectory().toFile().exists());
+        
+        // Test file path creation
+        java.nio.file.Path filePath = directories.createFilePath("test-file", "temp");
+        assertNotNull("File path should not be null", filePath);
+        assertTrue("File path should contain test-file", filePath.toString().contains("test-file"));
+        assertTrue("File path should contain temp", filePath.toString().contains("temp"));
+        assertTrue("File path should end with .csv", filePath.toString().endsWith(".csv"));
+    }
+
+    @Test
+    public void testFilePathGeneration() {
+        // Test different file path scenarios
+        java.nio.file.Path path1 = directories.createFilePath("export");
+        java.nio.file.Path path2 = directories.createFilePath("export", "1");
+        java.nio.file.Path path3 = directories.createFilePath("export", "temp");
+
+        assertNotEquals("Different paths should be generated", path1, path2);
+        assertNotEquals("Different paths should be generated", path1, path3);
+        assertNotEquals("Different paths should be generated", path2, path3);
+
+        assertTrue("All paths should end with .csv", path1.toString().endsWith(".csv"));
+        assertTrue("All paths should end with .csv", path2.toString().endsWith(".csv"));
+        assertTrue("All paths should end with .csv", path3.toString().endsWith(".csv"));
+    }
+
+    @Test
+    public void testEmptyStringValidation() {
+        // Test various empty string scenarios
+        String[] emptyStrings = {"", "   ", "\t", "\n", "\r\n"};
+        
+        for (String emptyString : emptyStrings) {
+            try {
+                new Neo4jStreamWriter(emptyString, "neo4j", "password", directories);
+                fail("Should have thrown IllegalArgumentException for empty URI: '" + emptyString + "'");
+            } catch (IllegalArgumentException e) {
+                // Expected
+                assertTrue("Error message should mention URI", 
+                    e.getMessage().toLowerCase().contains("uri"));
+            }
+        }
+    }
+
+    @Test
+    public void testValidUriFormats() {
+        // Test that various valid URI formats pass validation (will fail on connection)
+        String[] validUris = {
+            "bolt://localhost:7687",
+            "bolt+s://localhost:7687",
+            "bolt+ssc://localhost:7687",
+            "neo4j://localhost:7687",
+            "neo4j+s://localhost:7687",
+            "neo4j+ssc://localhost:7687"
+        };
+
+        for (String uri : validUris) {
+            try {
+                new Neo4jStreamWriter(uri, "neo4j", "password", directories);
+                fail("Should have thrown RuntimeException due to connection failure for URI: " + uri);
+            } catch (RuntimeException e) {
+                // Expected - connection will fail, but validation should pass
+                assertTrue("Should fail due to connection, not validation for URI: " + uri, 
+                    e.getMessage().contains("Failed to connect to Neo4j database"));
+            }
+        }
+    }
+
+    @Test
+    public void testUsernameAndPasswordValidation() {
+        // Test that empty username and password are allowed (some Neo4j setups don't require auth)
+        try {
+            new Neo4jStreamWriter("bolt://localhost:7687", "", "", directories);
+            fail("Should have thrown RuntimeException due to connection failure");
+        } catch (RuntimeException e) {
+            // Expected - connection will fail, but validation should pass
+            assertTrue("Should fail due to connection, not validation", 
+                e.getMessage().contains("Failed to connect to Neo4j database"));
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
N/a

*Description of changes:*
This PR adds a the ability to write streamed csv data from neoj4 database to a temp csv file, which then gets converted into neptune accepted formats via the usual file conversion process. 

Modifications were done to user input, where in addition to file input, one can either provide the full Neo4j database URI, username, and password, or provide a .net file with the credentials to initial streaming. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
