### PR TITLE
Added the ability to update node/edge labels and skip elements by ID/label with YAML config

### DIFF
--- a/neo4j-to-neptune/bin/neo4j-to-neptune.sh
+++ b/neo4j-to-neptune/bin/neo4j-to-neptune.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+jar=$(find . -name neo4j-to-neptune.jar -print -quit)
+java -jar ${jar} "$@"

--- a/neo4j-to-neptune/docs/conversion-config.md
+++ b/neo4j-to-neptune/docs/conversion-config.md
@@ -1,0 +1,185 @@
+# Label Mapping and Record Filtering
+
+The `convert-csv` utility supports mapping vertex and edge labels and filtering records during the conversion process from Neo4j to Neptune format. This feature allows you to rename labels to follow different naming conventions, resolve naming conflicts, and exclude specific vertices and edges from the conversion.
+
+## Usage
+
+Use the `--conversion-config` parameter to specify a YAML file containing the label mappings and filtering rules:
+
+```bash
+java -jar neo4j-to-neptune.jar convert-csv \
+  -i /tmp/neo4j-export.csv \
+  -d output \
+  --conversion-config  config.yaml \
+  --infer-types
+```
+
+## YAML Configuration Format
+
+The configuration file should be in YAML format with sections for label mapping and record filtering:
+
+```yaml
+# Vertex label mappings
+vertex_labels:
+  OldVertexLabel: NewVertexLabel
+  Person: Individual
+  Company: Organization
+  Product: Item
+
+# Edge label mappings  
+edge_labels:
+  OLD_RELATIONSHIP_TYPE: NEW_RELATIONSHIP_TYPE
+  WORKS_FOR: EMPLOYED_BY
+  LIVES_IN: RESIDES_IN
+  KNOWS: CONNECTED_TO
+
+# Skip vertices configuration
+skip_vertices:
+  # Skip vertices by their specific IDs
+  by_id:
+    - "vertex_123"
+    - "vertex_456"
+    - "user_999"
+  
+  # Skip vertices by their labels
+  by_label:
+    - "TestData"
+    - "Deprecated"
+    - "TempNode"
+
+# Skip edges configuration
+skip_edges:
+  # Skip edges by their relationship types
+  by_label:
+    - "TEMP_RELATIONSHIP"
+    - "DEBUG_LINK"
+    - "OLD_CONNECTION"
+```
+_**Note:** label only for edge as Neo4j default csv export doesn't include original edge IDs._
+
+_**Tip:** To avoid long bullet lists, one could use the alternative YAML format for list input:_
+```yaml
+skip_vertices:
+  by_id: ["vertex_123","vertex_456","user_999"]
+```
+
+## Label Mapping
+
+### Vertex Labels
+
+- Neo4j vertices can have multiple labels separated by colons (e.g., `Person:Employee`)
+- Each individual label is mapped independently if a mapping exists
+- Unmapped labels are kept as-is
+- The output uses semicolons as separators (Neptune format)
+
+**Example:**
+- Input: `Person:Employee` with mapping `Person: Individual`
+- Output: `Individual;Employee`
+
+### Edge Labels
+
+- Neo4j relationships have a single type/label
+- The entire label is mapped if a mapping exists
+- Unmapped labels are kept as-is
+
+**Example:**
+- Input: `WORKS_FOR` with mapping `WORKS_FOR: EMPLOYED_BY`
+- Output: `EMPLOYED_BY`
+
+## Record Filtering
+
+### Skip Vertices
+
+You can skip vertices in two ways:
+
+1. **By ID**: Skip specific vertices by their unique identifiers (note that IDs are treated as strings)
+2. **By Label**: Skip all vertices that have any of the specified labels
+
+When a vertex is skipped:
+- The vertex is not written to the output vertices CSV file
+- All edges connected to that vertex (incoming and outgoing) are automatically skipped
+- The skipped vertex ID is tracked for edge filtering
+
+### Skip Edges
+
+You can skip edges in following way:
+
+1. **By Label**: Skip all edges of the specified relationship types
+
+_**Note:** label only for edge as Neo4j default csv export doesn't include original edge IDs._
+
+### Automatic Edge Filtering
+
+When vertices are skipped, the system automatically skips any edges that connect to or from those vertices. This ensures data consistency in the output.
+
+**Example:**
+- If vertex `123` is skipped
+- Edge `456 -> 123` is automatically skipped
+- Edge `123 -> 789` is automatically skipped
+- Edge `456 -> 789` is preserved (if neither 456 nor 789 are skipped)
+
+## Behavior
+
+- **Optional**: All configuration sections are optional
+- **Partial configurations**: You can use only label mapping, only filtering, or both
+- **Case-sensitive**: All mappings and filters are case-sensitive
+- **Whitespace handling**: Leading and trailing whitespace is trimmed
+- **Empty sections**: Any section can be omitted if not needed
+
+## Output Statistics
+
+When filtering is enabled, the conversion process reports:
+- Number of vertices processed and skipped
+- Number of edges processed and skipped
+- Summary of skip rules applied
+
+**Example output:**
+```
+Vertices: 1500
+Edges   : 2300
+Skipped vertices: 25
+Skipped edges  : 78
+Skip rules: 3 vertex IDs, 2 vertex labels, 1 edge labels
+Output  : output/1234567890
+```
+
+## Complete Example
+
+Given a Neo4j export with:
+- Vertices: `Person:Manager`, `TestData:Person`, `Company`
+- Edges: `REPORTS_TO`, `TEMP_RELATIONSHIP`
+
+And the following configuration:
+
+```yaml
+vertex_labels:
+  Person: Individual
+  Manager: Supervisor
+  Company: Organization
+
+edge_labels:
+  REPORTS_TO: MANAGED_BY
+
+skip_vertices:
+  by_label:
+    - "TestData"
+
+skip_edges:
+  by_label:
+    - "TEMP_RELATIONSHIP"
+```
+
+The conversion will produce:
+- Vertex `Person:Manager` → `Individual;Supervisor`
+- Vertex `TestData:Person` → **skipped**
+- Vertex `Company` → `Organization`
+- Edge `REPORTS_TO` → `MANAGED_BY`
+- Edge `TEMP_RELATIONSHIP` → **skipped**
+- Any edges connected to the skipped `TestData:Person` vertex → **skipped**
+
+## Error Handling
+
+- If the mapping file doesn't exist, the conversion will fail with an error
+- If the YAML file is malformed, the conversion will fail with a parsing error
+- If the YAML file exists but is empty or has no configurations, the conversion proceeds without modifications
+- Invalid skip rules (e.g. non-existent IDs, mismatched labels) are silently ignored

--- a/neo4j-to-neptune/docs/convert-csv.md
+++ b/neo4j-to-neptune/docs/convert-csv.md
@@ -4,7 +4,9 @@
     
     SYNOPSIS
             neo4j-to-neptune.sh convert-csv {-d | --dir} <outputDirectory>
-                    {-i | --input} <inputFile> [ --infer-types ]
+                    {-i | --input} <inputFile> 
+                    [ --conversion-config <conversionConfigYAMLFile> ]
+                    [ --infer-types ]
                     [ --node-property-policy <multiValuedNodePropertyPolicy> ]
                     [ --relationship-property-policy <multiValuedRelationshipPropertyPolicy> ]
                     [ --semi-colon-replacement <semiColonReplacement> ]
@@ -30,6 +32,14 @@
                 exist on the file system. The provided path must be readable and
                 writable.
     
+            --conversion-config <conversionConfigYAMLFile>
+                Path to conversion configuration YAML file
+    
+                This option may occur a maximum of 1 times
+    
+    
+                This options value must be a path to a file. The provided path must
+                exist on the file system. The provided path must be readable.
     
             --infer-types
                 Infer data types for CSV column headings

--- a/neo4j-to-neptune/docs/example-conversion-config.yaml
+++ b/neo4j-to-neptune/docs/example-conversion-config.yaml
@@ -1,0 +1,45 @@
+# Example label mapping and filtering configuration for Neo4j to Neptune conversion
+# This file demonstrates how to map vertex and edge labels and skip certain records during conversion
+
+# Vertex label mappings
+# Format: OldLabel: NewLabel
+vertex_labels:
+  Person: Individual
+  Company: Organization
+  Product: Item
+  Location: Place
+  User: Customer
+
+# Edge label mappings
+# Format: OLD_RELATIONSHIP_TYPE: NEW_RELATIONSHIP_TYPE
+edge_labels:
+  WORKS_FOR: EMPLOYED_BY
+  LIVES_IN: RESIDES_IN
+  OWNS: POSSESSES
+  KNOWS: CONNECTED_TO
+  PURCHASED: BOUGHT
+  MANAGES: SUPERVISES
+
+# Skip vertices configuration
+# Input takes lists, can use alternative format, e.g. by_id: [1,2,3]
+skip_vertices:
+  # Skip vertices by their specific IDs
+  by_id:
+    - "vertex_123"
+    - "vertex_456"
+    - "user_999"
+
+  # Skip vertices by their labels (any vertex with these labels will be skipped)
+  by_label:
+    - "TestData"
+    - "Deprecated"
+    - "TempNode"
+
+# Skip edges configuration
+skip_edges:
+  # Skip edges by their relationship types
+  # (Note: label only for edge as Neo4j default csv export doesn't include original edge IDs)
+  by_label:
+    - "TEMP_RELATIONSHIP"
+    - "DEBUG_LINK"
+    - "OLD_CONNECTION"

--- a/neo4j-to-neptune/pom.xml
+++ b/neo4j-to-neptune/pom.xml
@@ -48,9 +48,44 @@
         </dependency>
 
         <dependency>
+            <groupId>org.neo4j.driver</groupId>
+            <artifactId>neo4j-java-driver</artifactId>
+            <version>5.28.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>neptune</artifactId>
+            <version>2.31.32</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>neptunedata</artifactId>
+            <version>2.31.32</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>2.31.32</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.17.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/neo4j-to-neptune/src/main/java/com/amazonaws/services/neptune/metadata/ConversionConfig.java
+++ b/neo4j-to-neptune/src/main/java/com/amazonaws/services/neptune/metadata/ConversionConfig.java
@@ -1,0 +1,155 @@
+/*
+Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package com.amazonaws.services.neptune.metadata;
+
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Configuration class for label mapping and filtering from YAML file.
+ * <p>
+ * Expected YAML format:
+ * vertex_labels:
+ *   OldVertexLabel: NewVertexLabel
+ *   AnotherOldLabel: AnotherNewLabel
+ * edge_labels:
+ *   OLD_EDGE_TYPE: NEW_EDGE_TYPE
+ *   ANOTHER_OLD_TYPE: ANOTHER_NEW_TYPE
+ * skip_vertices:
+ *   by_id:
+ *     - "vertex_id_1"
+ *     - "vertex_id_2"
+ *   by_label:
+ *     - "LabelToSkip"
+ *     - "AnotherLabelToSkip"
+ * skip_edges:
+ *   by_label:
+ *     - "RELATIONSHIP_TYPE_TO_SKIP"
+ *     - "ANOTHER_TYPE_TO_SKIP"
+ */
+public class ConversionConfig {
+
+    private Map<String, String> vertexLabels = new HashMap<>();
+    private Map<String, String> edgeLabels = new HashMap<>();
+    private Set<String> skipVertexIds = new HashSet<>();
+    private Set<String> skipVertexLabels = new HashSet<>();
+    private Set<String> skipEdgeLabels = new HashSet<>();
+
+    public static ConversionConfig fromFile(File yamlFile) throws IOException {
+        if (yamlFile == null || !yamlFile.exists()) {
+            return new ConversionConfig(); // Return empty config if no file provided
+        }
+
+        Yaml yaml = new Yaml();
+        try (FileInputStream inputStream = new FileInputStream(yamlFile)) {
+            Map<String, Object> data = yaml.load(inputStream);
+
+            ConversionConfig config = new ConversionConfig();
+
+            if (data != null) {
+                // Load vertex label mappings
+                Object vertexLabelsObj = data.get("vertex_labels");
+                if (vertexLabelsObj instanceof Map) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, String> vertexMappings = (Map<String, String>) vertexLabelsObj;
+                    config.vertexLabels.putAll(vertexMappings);
+                }
+
+                // Load edge label mappings
+                Object edgeLabelsObj = data.get("edge_labels");
+                if (edgeLabelsObj instanceof Map) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, String> edgeMappings = (Map<String, String>) edgeLabelsObj;
+                    config.edgeLabels.putAll(edgeMappings);
+                }
+
+                // Load skip vertex configuration
+                Object skipVerticesObj = data.get("skip_vertices");
+                if (skipVerticesObj instanceof Map) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> skipVertices = (Map<String, Object>) skipVerticesObj;
+
+                    // Load vertex IDs to skip
+                    Object skipVertexIdsObj = skipVertices.get("by_id");
+                    if (skipVertexIdsObj instanceof List) {
+                        // YAML file allows numerical IDs, cast and treat as strings
+                        List<String> vertexIds = ((List<?>) skipVertexIdsObj).stream().map(Object::toString).collect(Collectors.toList());
+                        config.skipVertexIds.addAll(vertexIds);
+                    }
+
+                    // Load vertex labels to skip
+                    Object skipVertexLabelsObj = skipVertices.get("by_label");
+                    if (skipVertexLabelsObj instanceof List) {
+                        @SuppressWarnings("unchecked")
+                        List<String> vertexLabels = (List<String>) skipVertexLabelsObj;
+                        config.skipVertexLabels.addAll(vertexLabels);
+                    }
+                }
+
+                // Load skip edge configuration
+                Object skipEdgesObj = data.get("skip_edges");
+                if (skipEdgesObj instanceof Map) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> skipEdges = (Map<String, Object>) skipEdgesObj;
+
+                    // Load edge labels to skip
+                    Object skipEdgeLabelsObj = skipEdges.get("by_label");
+                    if (skipEdgeLabelsObj instanceof List) {
+                        @SuppressWarnings("unchecked")
+                        List<String> edgeLabels = (List<String>) skipEdgeLabelsObj;
+                        config.skipEdgeLabels.addAll(edgeLabels);
+                    }
+                }
+            }
+
+            return config;
+        }
+    }
+
+    public Map<String, String> getVertexLabels() {
+        return vertexLabels;
+    }
+
+    public Map<String, String> getEdgeLabels() {
+        return edgeLabels;
+    }
+
+    public Set<String> getSkipVertexIds() {
+        return skipVertexIds;
+    }
+
+    public Set<String> getSkipVertexLabels() {
+        return skipVertexLabels;
+    }
+
+    public Set<String> getSkipEdgeLabels() {
+        return skipEdgeLabels;
+    }
+
+    public boolean hasVertexMappings() {
+        return !vertexLabels.isEmpty();
+    }
+
+    public boolean hasEdgeMappings() {
+        return !edgeLabels.isEmpty();
+    }
+
+    public boolean hasSkipRules() {
+        return !skipVertexIds.isEmpty() || !skipVertexLabels.isEmpty() || !skipEdgeLabels.isEmpty();
+    }
+}

--- a/neo4j-to-neptune/src/main/java/com/amazonaws/services/neptune/metadata/LabelMapper.java
+++ b/neo4j-to-neptune/src/main/java/com/amazonaws/services/neptune/metadata/LabelMapper.java
@@ -1,0 +1,77 @@
+/*
+Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package com.amazonaws.services.neptune.metadata;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for mapping vertex and edge labels based on configuration.
+ */
+public class LabelMapper {
+    
+    private final Map<String, String> vertexLabelMappings;
+    private final Map<String, String> edgeLabelMappings;
+    
+    public LabelMapper(ConversionConfig config) {
+        this.vertexLabelMappings = config.getVertexLabels();
+        this.edgeLabelMappings = config.getEdgeLabels();
+    }
+    
+    /**
+     * Maps vertex labels. Neo4j vertex labels are colon-separated and can have multiple labels.
+     * Each individual label is mapped if a mapping exists, otherwise kept as-is.
+     * 
+     * @param originalLabels The original colon-separated vertex labels from Neo4j
+     * @return The mapped labels, semicolon-separated for Neptune format
+     */
+    public String mapVertexLabels(String originalLabels) {
+        if (originalLabels == null || originalLabels.trim().isEmpty()) {
+            return originalLabels;
+        }
+        
+        return Arrays.stream(originalLabels.split(":"))
+                .filter(s -> !s.isEmpty())
+                .map(label -> vertexLabelMappings.getOrDefault(label.trim(), label.trim()))
+                .collect(Collectors.joining(";"));
+    }
+    
+    /**
+     * Maps edge labels. Neo4j edge types are single values.
+     * 
+     * @param originalLabel The original edge type from Neo4j
+     * @return The mapped edge type, or original if no mapping exists
+     */
+    public String mapEdgeLabel(String originalLabel) {
+        if (originalLabel == null || originalLabel.trim().isEmpty()) {
+            return originalLabel;
+        }
+        
+        return edgeLabelMappings.getOrDefault(originalLabel.trim(), originalLabel.trim());
+    }
+    
+    /**
+     * Check if any vertex label mappings are configured.
+     */
+    public boolean hasVertexMappings() {
+        return !vertexLabelMappings.isEmpty();
+    }
+    
+    /**
+     * Check if any edge label mappings are configured.
+     */
+    public boolean hasEdgeMappings() {
+        return !edgeLabelMappings.isEmpty();
+    }
+}

--- a/neo4j-to-neptune/src/main/java/com/amazonaws/services/neptune/metadata/RecordFilter.java
+++ b/neo4j-to-neptune/src/main/java/com/amazonaws/services/neptune/metadata/RecordFilter.java
@@ -1,0 +1,169 @@
+/*
+Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package com.amazonaws.services.neptune.metadata;
+
+import org.apache.commons.csv.CSVRecord;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Utility class for filtering vertices and edges based on configuration rules.
+ * Handles skipping of vertices and edges by ID or label, and automatically
+ * skips edges connected to skipped vertices.
+ */
+public class RecordFilter {
+    
+    private final Set<String> skipVertexIds;
+    private final Set<String> skipVertexLabels;
+    private final Set<String> skipEdgeLabels;
+    private final Set<String> skippedVertexIds;
+    
+    public RecordFilter(ConversionConfig config) {
+        this.skipVertexIds = config.getSkipVertexIds();
+        this.skipVertexLabels = config.getSkipVertexLabels();
+        this.skipEdgeLabels = config.getSkipEdgeLabels();
+        this.skippedVertexIds = new HashSet<>();
+    }
+    
+    /**
+     * Determines if a vertex should be skipped based on its ID or labels.
+     * Also tracks skipped vertex IDs for edge filtering.
+     * 
+     * @param record The CSV record representing the vertex
+     * @param vertexMetadata Metadata for parsing vertex information
+     * @return true if the vertex should be skipped, false otherwise
+     */
+    public boolean shouldSkipVertex(CSVRecord record, VertexMetadata vertexMetadata) {
+        if (!hasSkipRules()) {
+            return false;
+        }
+        
+        String vertexId = record.get(0); // _id is always the first column
+        String vertexLabels = getVertexLabels(record, vertexMetadata);
+        
+        // Check if vertex ID should be skipped
+        if (skipVertexIds.contains(vertexId)) {
+            skippedVertexIds.add(vertexId);
+            return true;
+        }
+        
+        // Check if any vertex label should be skipped
+        if (vertexLabels != null && !vertexLabels.isEmpty()) {
+            String[] labels = vertexLabels.split(":");
+            for (String label : labels) {
+                String trimmedLabel = label.trim();
+                if (!trimmedLabel.isEmpty() && skipVertexLabels.contains(trimmedLabel)) {
+                    skippedVertexIds.add(vertexId);
+                    return true;
+                }
+            }
+        }
+        
+        return false;
+    }
+    
+    /**
+     * Determines if an edge should be skipped based on its ID, label, or connected vertices.
+     * 
+     * @param record The CSV record representing the edge
+     * @param edgeMetadata Metadata for parsing edge information
+     * @return true if the edge should be skipped, false otherwise
+     */
+    public boolean shouldSkipEdge(CSVRecord record, EdgeMetadata edgeMetadata) {
+        if (!hasSkipRules()) {
+            return false;
+        }
+        
+        int firstColumnIndex = edgeMetadata.firstColumnIndex();
+        
+        // Make sure we have enough columns for edge data
+        if (record.size() <= firstColumnIndex + 2) {
+            return false; // Not enough data to be a valid edge
+        }
+        
+        // The actual edge data starts at firstColumnIndex
+        String startVertexId = record.get(firstColumnIndex);     // _start
+        String endVertexId = record.get(firstColumnIndex + 1);   // _end
+        String edgeType = record.get(firstColumnIndex + 2);      // _type
+        
+        // Skip edge if either connected vertex was skipped
+        if (skippedVertexIds.contains(startVertexId) || skippedVertexIds.contains(endVertexId)) {
+            return true;
+        }
+        
+        // Check if edge type/label should be skipped
+        if (edgeType != null && !edgeType.trim().isEmpty() && skipEdgeLabels.contains(edgeType.trim())) {
+            return true;
+        }
+        
+        // If needed, this could be extended to support edge property-based filtering.
+        
+        return false;
+    }
+    
+    /**
+     * Gets the vertex labels from a CSV record.
+     */
+    private String getVertexLabels(CSVRecord record, VertexMetadata vertexMetadata) {
+        // In Neo4j CSV exports, _labels is typically at index 1 (after _id at index 0)
+        if (record.size() > 1) {
+            return record.get(1);
+        }
+        return null;
+    }
+    
+    /**
+     * Returns the set of vertex IDs that were skipped during processing.
+     * This is useful for reporting and debugging.
+     */
+    public Set<String> getSkippedVertexIds() {
+        return new HashSet<>(skippedVertexIds);
+    }
+    
+    /**
+     * Checks if any skip rules are configured.
+     */
+    public boolean hasSkipRules() {
+        return !skipVertexIds.isEmpty() || !skipVertexLabels.isEmpty() || !skipEdgeLabels.isEmpty();
+    }
+    
+    /**
+     * Returns statistics about skip rules.
+     */
+    public String getSkipStatistics() {
+        if (!hasSkipRules()) {
+            return "No skip rules configured";
+        }
+        
+        StringBuilder stats = new StringBuilder();
+        stats.append("Skip rules: ");
+        
+        if (!skipVertexIds.isEmpty()) {
+            stats.append(skipVertexIds.size()).append(" vertex IDs, ");
+        }
+        if (!skipVertexLabels.isEmpty()) {
+            stats.append(skipVertexLabels.size()).append(" vertex labels, ");
+        }
+        if (!skipEdgeLabels.isEmpty()) {
+            stats.append(skipEdgeLabels.size()).append(" edge labels, ");
+        }
+        
+        // Remove trailing comma and space
+        if (stats.toString().endsWith(", ")) {
+            stats.setLength(stats.length() - 2);
+        }
+        
+        return stats.toString();
+    }
+}

--- a/neo4j-to-neptune/src/test/java/com/amazonaws/services/neptune/metadata/LabelMapperTest.java
+++ b/neo4j-to-neptune/src/test/java/com/amazonaws/services/neptune/metadata/LabelMapperTest.java
@@ -1,0 +1,101 @@
+/*
+Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package com.amazonaws.services.neptune.metadata;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+public class LabelMapperTest {
+
+    @Test
+    public void testVertexLabelMapping() throws IOException {
+        // Create a temporary YAML file
+        File tempFile = File.createTempFile("test-mapping", ".yaml");
+        tempFile.deleteOnExit();
+        
+        try (FileWriter writer = new FileWriter(tempFile)) {
+            writer.write("vertex_labels:\n");
+            writer.write("  Person: Individual\n");
+            writer.write("  Company: Organization\n");
+            writer.write("edge_labels:\n");
+            writer.write("  WORKS_FOR: EMPLOYED_BY\n");
+        }
+        
+        ConversionConfig config = ConversionConfig.fromFile(tempFile);
+        LabelMapper mapper = new LabelMapper(config);
+        
+        // Test vertex label mapping
+        assertEquals("Individual", mapper.mapVertexLabels("Person"));
+        assertEquals("Individual;Organization", mapper.mapVertexLabels("Person:Company"));
+        assertEquals("Individual;Organization", mapper.mapVertexLabels(":Person:Company:"));
+        assertEquals("UnmappedLabel", mapper.mapVertexLabels("UnmappedLabel"));
+        assertEquals("Individual;UnmappedLabel", mapper.mapVertexLabels("Person:UnmappedLabel"));
+        
+        // Test edge label mapping
+        assertEquals("EMPLOYED_BY", mapper.mapEdgeLabel("WORKS_FOR"));
+        assertEquals("UNMAPPED_EDGE", mapper.mapEdgeLabel("UNMAPPED_EDGE"));
+        
+        // Test empty/null inputs
+        assertEquals("", mapper.mapVertexLabels(""));
+        assertNull(mapper.mapVertexLabels(null));
+        assertEquals("", mapper.mapEdgeLabel(""));
+        assertNull(mapper.mapEdgeLabel(null));
+    }
+    
+    @Test
+    public void testEmptyConfiguration() throws IOException {
+        ConversionConfig config = ConversionConfig.fromFile(null);
+        LabelMapper mapper = new LabelMapper(config);
+        
+        assertFalse(mapper.hasVertexMappings());
+        assertFalse(mapper.hasEdgeMappings());
+        
+        // Should return original labels when no mappings exist
+        assertEquals("Person;Company", mapper.mapVertexLabels("Person:Company"));
+        assertEquals("WORKS_FOR", mapper.mapEdgeLabel("WORKS_FOR"));
+    }
+    
+    @Test
+    public void testConfigurationLoading() throws IOException {
+        // Create a temporary YAML file
+        File tempFile = File.createTempFile("test-config", ".yaml");
+        tempFile.deleteOnExit();
+        
+        try (FileWriter writer = new FileWriter(tempFile)) {
+            writer.write("vertex_labels:\n");
+            writer.write("  Person: Individual\n");
+            writer.write("  Company: Organization\n");
+            writer.write("edge_labels:\n");
+            writer.write("  WORKS_FOR: EMPLOYED_BY\n");
+            writer.write("  KNOWS: CONNECTED_TO\n");
+        }
+        
+        ConversionConfig config = ConversionConfig.fromFile(tempFile);
+        
+        assertTrue(config.hasVertexMappings());
+        assertTrue(config.hasEdgeMappings());
+        
+        assertEquals(2, config.getVertexLabels().size());
+        assertEquals(2, config.getEdgeLabels().size());
+        
+        assertEquals("Individual", config.getVertexLabels().get("Person"));
+        assertEquals("Organization", config.getVertexLabels().get("Company"));
+        assertEquals("EMPLOYED_BY", config.getEdgeLabels().get("WORKS_FOR"));
+        assertEquals("CONNECTED_TO", config.getEdgeLabels().get("KNOWS"));
+    }
+}

--- a/neo4j-to-neptune/src/test/java/com/amazonaws/services/neptune/metadata/RecordFilterTest.java
+++ b/neo4j-to-neptune/src/test/java/com/amazonaws/services/neptune/metadata/RecordFilterTest.java
@@ -1,0 +1,251 @@
+/*
+Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package com.amazonaws.services.neptune.metadata;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVRecord;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.StringReader;
+
+import static org.junit.Assert.*;
+
+public class RecordFilterTest {
+
+    @Test
+    public void testVertexSkippingById() throws IOException {
+        // Create a temporary YAML file with vertex ID skip rules
+        File tempFile = File.createTempFile("test-skip", ".yaml");
+        tempFile.deleteOnExit();
+        
+        try (FileWriter writer = new FileWriter(tempFile)) {
+            writer.write("skip_vertices:\n");
+            writer.write("  by_id:\n");
+            writer.write("    - \"123\"\n");
+            writer.write("    - \"456\"\n");
+        }
+        
+        ConversionConfig config = ConversionConfig.fromFile(tempFile);
+        RecordFilter filter = new RecordFilter(config);
+        
+        // Create mock vertex metadata
+        String headerLine = "_id,_labels,name";
+        CSVRecord headers = CSVFormat.DEFAULT.parse(new StringReader(headerLine)).iterator().next();
+        VertexMetadata vertexMetadata = VertexMetadata.parse(headers, 
+            new PropertyValueParser(MultiValuedNodePropertyPolicy.PutInSetIgnoringDuplicates, " ", false));
+        
+        // Test vertex records
+        String vertexData = "123,Person,John\n456,Company,Acme\n789,Person,Jane";
+        Iterable<CSVRecord> records = CSVFormat.DEFAULT.parse(new StringReader(vertexData));
+        
+        int recordIndex = 0;
+        for (CSVRecord record : records) {
+            if (recordIndex == 0) {
+                assertTrue("Vertex 123 should be skipped", filter.shouldSkipVertex(record, vertexMetadata));
+            } else if (recordIndex == 1) {
+                assertTrue("Vertex 456 should be skipped", filter.shouldSkipVertex(record, vertexMetadata));
+            } else if (recordIndex == 2) {
+                assertFalse("Vertex 789 should not be skipped", filter.shouldSkipVertex(record, vertexMetadata));
+            }
+            recordIndex++;
+        }
+        
+        assertEquals(2, filter.getSkippedVertexIds().size());
+        assertTrue(filter.getSkippedVertexIds().contains("123"));
+        assertTrue(filter.getSkippedVertexIds().contains("456"));
+    }
+    
+    @Test
+    public void testVertexSkippingByLabel() throws IOException {
+        // Create a temporary YAML file with vertex label skip rules
+        File tempFile = File.createTempFile("test-skip-label", ".yaml");
+        tempFile.deleteOnExit();
+        
+        try (FileWriter writer = new FileWriter(tempFile)) {
+            writer.write("skip_vertices:\n");
+            writer.write("  by_label:\n");
+            writer.write("    - \"TestData\"\n");
+            writer.write("    - \"Deprecated\"\n");
+        }
+
+        ConversionConfig config = ConversionConfig.fromFile(tempFile);
+        RecordFilter filter = new RecordFilter(config);
+        
+        // Create mock vertex metadata
+        String headerLine = "_id,_labels,name";
+        CSVRecord headers = CSVFormat.DEFAULT.parse(new StringReader(headerLine)).iterator().next();
+        VertexMetadata vertexMetadata = VertexMetadata.parse(headers, 
+            new PropertyValueParser(MultiValuedNodePropertyPolicy.PutInSetIgnoringDuplicates, " ", false));
+        
+        // Test vertex records with different labels
+        String vertexData = "1,Person,John\n2,TestData,Test\n3,Person:Deprecated,Old\n4,Company,Acme";
+        Iterable<CSVRecord> records = CSVFormat.DEFAULT.parse(new StringReader(vertexData));
+        
+        int recordIndex = 0;
+        for (CSVRecord record : records) {
+            if (recordIndex == 0) {
+                assertFalse("Person vertex should not be skipped", filter.shouldSkipVertex(record, vertexMetadata));
+            } else if (recordIndex == 1) {
+                assertTrue("TestData vertex should be skipped", filter.shouldSkipVertex(record, vertexMetadata));
+            } else if (recordIndex == 2) {
+                assertTrue("Deprecated vertex should be skipped", filter.shouldSkipVertex(record, vertexMetadata));
+            } else if (recordIndex == 3) {
+                assertFalse("Company vertex should not be skipped", filter.shouldSkipVertex(record, vertexMetadata));
+            }
+            recordIndex++;
+        }
+    }
+    
+    @Test
+    public void testEdgeSkippingByConnectedVertices() throws IOException {
+        // Create a temporary YAML file with vertex skip rules
+        File tempFile = File.createTempFile("test-edge-skip", ".yaml");
+        tempFile.deleteOnExit();
+        
+        try (FileWriter writer = new FileWriter(tempFile)) {
+            writer.write("skip_vertices:\n");
+            writer.write("  by_id:\n");
+            writer.write("    - \"123\"\n");
+        }
+
+        ConversionConfig config = ConversionConfig.fromFile(tempFile);
+        RecordFilter filter = new RecordFilter(config);
+        
+        // Create mock metadata
+        String headerLine = "_id,_labels,name,_start,_end,_type";
+        CSVRecord headers = CSVFormat.DEFAULT.parse(new StringReader(headerLine)).iterator().next();
+        VertexMetadata vertexMetadata = VertexMetadata.parse(headers, 
+            new PropertyValueParser(MultiValuedNodePropertyPolicy.PutInSetIgnoringDuplicates, " ", false));
+        EdgeMetadata edgeMetadata = EdgeMetadata.parse(headers, 
+            new PropertyValueParser(MultiValuedRelationshipPropertyPolicy.LeaveAsString, " ", false));
+        
+        // First, skip vertex 123
+        String vertexData = "123,Person,John";
+        CSVRecord vertexRecord = CSVFormat.DEFAULT.parse(new StringReader(vertexData)).iterator().next();
+        filter.shouldSkipVertex(vertexRecord, vertexMetadata);
+        
+        // Test edge records
+        String edgeData = ",,,456,789,KNOWS\n,,,123,789,WORKS_FOR\n,,,456,123,MANAGES";
+        Iterable<CSVRecord> edgeRecords = CSVFormat.DEFAULT.parse(new StringReader(edgeData));
+        
+        int recordIndex = 0;
+        for (CSVRecord record : edgeRecords) {
+            if (recordIndex == 0) {
+                assertFalse("Edge between 456-789 should not be skipped", filter.shouldSkipEdge(record, edgeMetadata));
+            } else if (recordIndex == 1) {
+                assertTrue("Edge from 123-789 should be skipped (123 is skipped vertex)", filter.shouldSkipEdge(record, edgeMetadata));
+            } else if (recordIndex == 2) {
+                assertTrue("Edge from 456-123 should be skipped (123 is skipped vertex)", filter.shouldSkipEdge(record, edgeMetadata));
+            }
+            recordIndex++;
+        }
+    }
+    
+    @Test
+    public void testEdgeSkippingByLabel() throws IOException {
+        // Create a temporary YAML file with edge label skip rules
+        File tempFile = File.createTempFile("test-edge-label-skip", ".yaml");
+        tempFile.deleteOnExit();
+        
+        try (FileWriter writer = new FileWriter(tempFile)) {
+            writer.write("skip_edges:\n");
+            writer.write("  by_label:\n");
+            writer.write("    - \"TEMP_RELATIONSHIP\"\n");
+            writer.write("    - \"DEBUG_LINK\"\n");
+        }
+
+        ConversionConfig config = ConversionConfig.fromFile(tempFile);
+        RecordFilter filter = new RecordFilter(config);
+        
+        // Create mock edge metadata
+        String headerLine = "_id,_labels,name,_start,_end,_type";
+        CSVRecord headers = CSVFormat.DEFAULT.parse(new StringReader(headerLine)).iterator().next();
+        EdgeMetadata edgeMetadata = EdgeMetadata.parse(headers, 
+            new PropertyValueParser(MultiValuedRelationshipPropertyPolicy.LeaveAsString, " ", false));
+        
+        // Test edge records with different types
+        String edgeData = ",,,1,2,KNOWS\n,,,2,3,TEMP_RELATIONSHIP\n,,,3,4,DEBUG_LINK\n,,,4,5,WORKS_FOR";
+        Iterable<CSVRecord> records = CSVFormat.DEFAULT.parse(new StringReader(edgeData));
+        
+        int recordIndex = 0;
+        for (CSVRecord record : records) {
+            if (recordIndex == 0) {
+                assertFalse("KNOWS edge should not be skipped", filter.shouldSkipEdge(record, edgeMetadata));
+            } else if (recordIndex == 1) {
+                assertTrue("TEMP_RELATIONSHIP edge should be skipped", filter.shouldSkipEdge(record, edgeMetadata));
+            } else if (recordIndex == 2) {
+                assertTrue("DEBUG_LINK edge should be skipped", filter.shouldSkipEdge(record, edgeMetadata));
+            } else if (recordIndex == 3) {
+                assertFalse("WORKS_FOR edge should not be skipped", filter.shouldSkipEdge(record, edgeMetadata));
+            }
+            recordIndex++;
+        }
+    }
+    
+    @Test
+    public void testNoSkipRules() throws IOException {
+        ConversionConfig config = ConversionConfig.fromFile(null);
+        RecordFilter filter = new RecordFilter(config);
+        
+        assertFalse(filter.hasSkipRules());
+        assertEquals("No skip rules configured", filter.getSkipStatistics());
+        
+        // Create mock metadata and records
+        String headerLine = "_id,_labels,name,_start,_end,_type";
+        CSVRecord headers = CSVFormat.DEFAULT.parse(new StringReader(headerLine)).iterator().next();
+        VertexMetadata vertexMetadata = VertexMetadata.parse(headers, 
+            new PropertyValueParser(MultiValuedNodePropertyPolicy.PutInSetIgnoringDuplicates, " ", false));
+        EdgeMetadata edgeMetadata = EdgeMetadata.parse(headers, 
+            new PropertyValueParser(MultiValuedRelationshipPropertyPolicy.LeaveAsString, " ", false));
+        
+        // Test that nothing is skipped when no rules are configured
+        String vertexData = "123,Person,John";
+        CSVRecord vertexRecord = CSVFormat.DEFAULT.parse(new StringReader(vertexData)).iterator().next();
+        assertFalse(filter.shouldSkipVertex(vertexRecord, vertexMetadata));
+        
+        String edgeData = ",,,,1,2,KNOWS";
+        CSVRecord edgeRecord = CSVFormat.DEFAULT.parse(new StringReader(edgeData)).iterator().next();
+        assertFalse(filter.shouldSkipEdge(edgeRecord, edgeMetadata));
+    }
+    
+    @Test
+    public void testSkipStatistics() throws IOException {
+        // Create a comprehensive YAML file
+        File tempFile = File.createTempFile("test-stats", ".yaml");
+        tempFile.deleteOnExit();
+        
+        try (FileWriter writer = new FileWriter(tempFile)) {
+            writer.write("skip_vertices:\n");
+            writer.write("  by_id:\n");
+            writer.write("    - \"1\"\n");
+            writer.write("    - \"2\"\n");
+            writer.write("  by_label:\n");
+            writer.write("    - \"TestData\"\n");
+            writer.write("skip_edges:\n");
+            writer.write("  by_label:\n");
+            writer.write("    - \"TEMP\"\n");
+        }
+
+        ConversionConfig config = ConversionConfig.fromFile(tempFile);
+        RecordFilter filter = new RecordFilter(config);
+        
+        assertTrue(filter.hasSkipRules());
+        String stats = filter.getSkipStatistics();
+        assertTrue(stats.contains("2 vertex IDs"));
+        assertTrue(stats.contains("1 vertex labels"));
+        assertTrue(stats.contains("1 edge labels"));
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
N/a

*Description of changes:*

Added an optional `--conversion-config` flag that takes in a YAML file with label mapping and record skipping configurations, which will update node/edge labels accordingly and skip elements specified by IDs/labels.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
